### PR TITLE
修复在windows系统下 文件路径的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (qiniu, option) {
   return through2.obj(function (file, enc, next) {
     var that = this;
     var isIgnore = false;
-    var filePath = path.relative(file.base, file.path);
+    var filePath = path.relative(file.base, file.path).split(path.sep).join('/');
 
     if (file._contents === null) return next();
     option.ignore.forEach(function(item) {


### PR DESCRIPTION
windows 系统下 文件路径是用 `\\` 来分隔的，不像 Linux 或者 OS X 那样用 `/` ，所以，这个插件在 windows 系统下上传到七牛后会出现这样的 url ：

```
http://bucket.qiniucdn.com/css\style.css
```

类似的情况在其他插件中也有出现。。。

解决办法就是用 `path.sep` 来替换这个分隔符。